### PR TITLE
Fix linter error in Kata 4

### DIFF
--- a/spec/Kata4.spec.php
+++ b/spec/Kata4.spec.php
@@ -9,10 +9,10 @@ use Katas\Kata4;
  */
 function isArraySorted($array): bool
 {
-	$i=0;
+	$i = 0;
 	$total_elements = count($array);
 	while ($total_elements > 1) {
-		if ($array[$i] <= $array[$i+1]) {
+		if ($array[$i] <= $array[$i + 1]) {
 			$i++;
 			$total_elements--;
 		} else {


### PR DESCRIPTION
The script `script/test` was throwing a linter error for Kata 4, which I've let it fix automatically.

# How to test

1. Run `script/setup` to setup all dependencies
2. Run `script/test` to run the linter
3. Confirm that there are no more errors